### PR TITLE
Revamp EkaScribe docs: Quick Start, reorder integrations, fix SDK titles

### DIFF
--- a/api-reference/health-ai/ekascribe/SDKs/TS-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/TS-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: "TypeScript SDK"
+---
+
 # Eka Care Ekascribe Typescript SDK Integration
 
 This guide explains how to integrate the Eka Care Ekascribe Typescript SDK into your application.

--- a/api-reference/health-ai/ekascribe/SDKs/android-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/android-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: "Android SDK"
+---
+
 # EkaScribe SDK Documentation
 
 EkaScribe SDK (Voice2Rx) is an Android SDK for voice-based medical transcription and documentation.

--- a/api-reference/health-ai/ekascribe/SDKs/ios-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/ios-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: "iOS SDK"
+---
+
 # EkaScribe iOS SDK
 
 A Swift package for voice-to-prescription functionality with audio recording and real-time transcription capabilities for medical consultation applications.

--- a/api-reference/health-ai/ekascribe/SDKs/java-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/java-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: "Java SDK"
+---
+
 # Eka Care Ekascribe Java SDK Integration
 
 This guide explains how to integrate the Eka Care Ekascribe Java SDK.

--- a/api-reference/health-ai/ekascribe/SDKs/python-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/python-sdk.mdx
@@ -1,3 +1,7 @@
+---
+title: "Python SDK"
+---
+
 # Eka Care Ekascribe Python SDK Integration
 
 This guide explains how to integrate the Eka Care Ekascribe Python SDK.

--- a/api-reference/health-ai/ekascribe/System-Requirements.mdx
+++ b/api-reference/health-ai/ekascribe/System-Requirements.mdx
@@ -1,4 +1,6 @@
-
+---
+title: "System Requirements for Extension"
+---
 
 Before integrating EkaScribe, ensure your system meets the following requirements:
 

--- a/api-reference/health-ai/ekascribe/ekascribe-v1/retrieve-transcribe.mdx
+++ b/api-reference/health-ai/ekascribe/ekascribe-v1/retrieve-transcribe.mdx
@@ -1,7 +1,10 @@
 ---
-title: Retrieve Result
+title: "Retrieve Result"
 openapi: GET /voice-record/api/status/{session_id}
+icon: "triangle-exclamation"
 ---
+
+<Warning>This API is deprecated. Please use the [EkaScribe v2 APIs](/api-reference/health-ai/ekascribe/ekascribe-v2/overview) or the [SDKs](/api-reference/health-ai/ekascribe/quick-start) instead.</Warning>
 
 ### Code to decode base64 encoded FHIR response
 

--- a/api-reference/health-ai/ekascribe/ekascribe-v1/upload-voice.mdx
+++ b/api-reference/health-ai/ekascribe/ekascribe-v1/upload-voice.mdx
@@ -1,3 +1,7 @@
 ---
+title: "Upload Voice"
 openapi: "POST /voice/upload?mode={mode}&txnid={txnid}"
+icon: "triangle-exclamation"
 ---
+
+<Warning>This API is deprecated. Please use the [EkaScribe v2 APIs](/api-reference/health-ai/ekascribe/ekascribe-v2/overview) or the [SDKs](/api-reference/health-ai/ekascribe/quick-start) instead.</Warning>

--- a/api-reference/health-ai/ekascribe/overview.mdx
+++ b/api-reference/health-ai/ekascribe/overview.mdx
@@ -12,24 +12,10 @@ EkaScribe offers **3 different ways** to integrate voice-to-text functionality i
 
 
 
-### 1. 🔌 **Chrome Extension** 
-*Ready-to-use browser extension*
-
-**What it is**: A browser extension that works directly in Chrome  
-**Who it's for**: Individual doctors, clinics, or practices wanting immediate access  
-**Requirements**: Chrome browser only  
-
-**How it works**: 
-- Install extension → Click record → Get structured medical notes
-- No coding required
-- Works on any website or application
-
-**Get Started**: [Download Chrome Extension](https://chromewebstore.google.com/detail/ekascribe-ai-powered-clin/nncfcjgelepkhpjfkejgkncdfbcfmhom)
-
----
-
-### 2. 📱 **SDKs** 
+### 1. 📱 **SDKs** *(Recommended)*
 *Pre-built libraries for your applications*
+
+<Info>We recommend the SDK approach, as it simplifies implementation by handling voice activity detection (VAD), audio chunking, uploads, and other complexities and makes it easy to plug into your existing workflow.</Info>
 
 **What it is**: Ready-to-use code libraries that handle all the complexity  
 **Who it's for**: Development teams building mobile apps or backend services  
@@ -50,7 +36,7 @@ EkaScribe offers **3 different ways** to integrate voice-to-text functionality i
 
 ---
 
-### 3. 🌐 **REST APIs** 
+### 2. 🌐 **REST APIs** 
 *Direct API access for custom integrations*
 
 **What it is**: Raw HTTP endpoints that you call directly  
@@ -69,6 +55,22 @@ EkaScribe offers **3 different ways** to integrate voice-to-text functionality i
 - Real-time status tracking
 
 **📖 [View Complete API Documentation →](https://developer.eka.care/api-reference/health-ai/ekascribe/ekascribe-v2/overview)**
+
+---
+
+### 3. 🔌 **Chrome Extension** 
+*Ready-to-use browser extension*
+
+**What it is**: A browser extension that works directly in Chrome  
+**Who it's for**: Individual doctors, clinics, or practices wanting immediate access  
+**Requirements**: Chrome browser only  
+
+**How it works**: 
+- Install extension → Click record → Get structured medical notes
+- No coding required
+- Works on any website or application
+
+**Get Started**: [Download Chrome Extension](https://chromewebstore.google.com/detail/ekascribe-ai-powered-clin/nncfcjgelepkhpjfkejgkncdfbcfmhom)
 
 > **Choose the integration method that works best for your setup** and start enhancing productivity while EkaScribe takes care of the documentation.
 

--- a/api-reference/health-ai/ekascribe/quick-start.mdx
+++ b/api-reference/health-ai/ekascribe/quick-start.mdx
@@ -1,0 +1,93 @@
+---
+title: "Quick Start"
+tag: "New"
+description: "A step by step guide to integrate EkaScribe into your application in just few minutes"
+---
+
+We recommend the SDK approach as it simplifies implementation by handling voice activity detection (VAD), audio chunking, uploads, and other complexities, making it easy to plug into your existing workflow.
+
+## Step 1: Get Your API Credentials
+
+You need a `client_id` and `client_secret` to authenticate with EkaScribe.
+
+<Steps>
+  <Step title="Create an Eka Account">
+    <a href="https://login.eka.care/workspace/sign-in/?next=https://console.eka.care&product_type=emr&signup=user_only&tab=sign-up" target="_blank">Sign up on Eka</a> if you haven't already.
+  </Step>
+  <Step title="Generate API Credentials">
+    Go to the <a href="https://console.eka.care" target="_blank">Eka Developer Console</a>, navigate to **Manage API Credentials**, and create a new client.
+  </Step>
+  <Step title="Save Your Credentials">
+    Copy your `client_id` and `client_secret`. Store them securely, the secret won't be shown again.
+    <Tip>You can create a long live token against your client ID, which you can directly pass as an access token.</Tip>
+  </Step>
+  <Step title="Get Access Token">
+    Use the [Client Login API](/api-reference/authorization/client-login) to obtain an access token, or use your long live token.
+  </Step>
+</Steps>
+
+**[View detailed authentication guide →](/api-reference/authorization/getting-started)**
+
+---
+
+## Step 2: Install the SDK
+
+We recommend the **TypeScript SDK** for the fastest plug-and-play integration.
+
+```bash
+npm install @eka-care/ekascribe-ts-sdk
+# or
+yarn add @eka-care/ekascribe-ts-sdk
+```
+
+---
+
+## Step 3: Start Transcribing
+
+Here's a complete working example to record a consultation and get structured medical notes:
+
+```ts
+// 1. Create a config variable to manage tokens
+const sdkConfig = {
+  access_token: '<your_access_token>',
+};
+
+// Get instance and use it throughout your application
+const ekascribe = getEkaScribeInstance(sdkConfig);
+
+// 2. Fetch available configurations (languages, templates, etc.)
+const config = await ekascribe.getEkascribeConfig();
+
+// 3. Initialize a transcription session
+await ekascribe.initTransaction({
+  mode: 'consultation',
+  input_language: ['en-IN'],
+  output_format_template: [{ template_id: 'your_template_id' }],
+  txn_id: 'unique-transaction-id',
+  transfer: 'vaded',
+  model_type: 'pro',
+});
+
+// 4. Start recording - microphone permission will be requested
+await ekascribe.startRecording();
+
+// ... consultation happens ...
+
+// 5. Stop recording - SDK handles chunking, upload & commit automatically
+await ekascribe.endRecording();
+
+// 6. Get the structured output
+const result = await ekascribe.pollSessionOutput({
+  txn_id: 'unique-transaction-id',
+});
+
+console.log(result);
+```
+
+That's it. The SDK handles VAD, audio chunking, file uploads, retries, and polling - you just call the methods.
+
+---
+
+## Explore Other Integration Options
+
+You can also integrate EkaScribe using [other SDKs](/api-reference/health-ai/ekascribe/overview#1--sdks-recommended), [REST APIs](/api-reference/health-ai/ekascribe/ekascribe-v2/overview), or the [Chrome Extension](https://chromewebstore.google.com/detail/ekascribe-ai-powered-clin/nncfcjgelepkhpjfkejgkncdfbcfmhom).

--- a/docs.json
+++ b/docs.json
@@ -198,7 +198,18 @@
                                         "icon": "microphone-lines",
                                         "pages": [
                                             "api-reference/health-ai/ekascribe/overview",
-                                            "api-reference/health-ai/ekascribe/System-Requirements",
+                                            "api-reference/health-ai/ekascribe/quick-start",
+                                            {
+                                                "group": "EkaScribe SDKs",
+                                                "icon": "microphone-lines",
+                                                "pages": [
+                                                    "api-reference/health-ai/ekascribe/SDKs/TS-sdk",
+                                                    "api-reference/health-ai/ekascribe/SDKs/python-sdk",
+                                                    "api-reference/health-ai/ekascribe/SDKs/java-sdk",
+                                                    "api-reference/health-ai/ekascribe/SDKs/android-sdk",
+                                                    "api-reference/health-ai/ekascribe/SDKs/ios-sdk"
+                                                ]
+                                            },
                                             {
                                                 "group": "EkaScribe APIs",
                                                 "icon": "microphone-lines",
@@ -207,38 +218,27 @@
                                                     "api-reference/health-ai/ekascribe/ekascribe-v2/presigned-url",
                                                     "api-reference/health-ai/ekascribe/ekascribe-v2/file-upload",
                                                     "api-reference/health-ai/ekascribe/ekascribe-v2/init",
-                                                    "api-reference/health-ai/ekascribe/ekascribe-v2/result"
-                                                ]
-                                            },
-                                            {
-                                                "group": "EkaScribe SDKs",
-                                                "icon": "microphone-lines",
-                                                "pages": [
-                                                    "api-reference/health-ai/ekascribe/SDKs/python-sdk",
-                                                    "api-reference/health-ai/ekascribe/SDKs/java-sdk",
-                                                    "api-reference/health-ai/ekascribe/SDKs/android-sdk",
-                                                    "api-reference/health-ai/ekascribe/SDKs/ios-sdk",
-                                                    "api-reference/health-ai/ekascribe/SDKs/TS-sdk"
-                                                ]
-                                            },
-                                            {
-                                                "group": "APIs - DEPRECATED",
-                                                "icon": "microphone-lines",
-                                                "pages": [
-                                                    "api-reference/health-ai/ekascribe/ekascribe-v1/upload-voice",
-                                                    "api-reference/health-ai/ekascribe/ekascribe-v1/retrieve-transcribe"
+                                                    "api-reference/health-ai/ekascribe/ekascribe-v2/result",
+                                                    {
+                                                        "group": "APIs - DEPRECATED",
+                                                        "icon": "triangle-exclamation",
+                                                        "pages": [
+                                                            "api-reference/health-ai/ekascribe/ekascribe-v1/upload-voice",
+                                                            "api-reference/health-ai/ekascribe/ekascribe-v1/retrieve-transcribe"
+                                                        ]
+                                                    }
                                                 ]
                                             },
                                             "api-reference/health-ai/ekascribe/audio-transcription",
                                             {
-                                                "group": "IP Allowlisting",
+                                                "group": "System Requirements",
                                                 "icon": "list-check",
                                                 "pages": [
-                                                    "api-reference/health-ai/ekascribe/ip-allowlisting-for-clients"
+                                                    "api-reference/health-ai/ekascribe/ip-allowlisting-for-clients",
+                                                    "api-reference/health-ai/ekascribe/System-Requirements"
                                                 ]
                                             },
-                                            "api-reference/health-ai/ekascribe/FHIR/Eka-FHIR-structure",
-                                            "api-reference/health-ai/ekascribe/ip-whitelisting-for-clients"
+                                            "api-reference/health-ai/ekascribe/FHIR/Eka-FHIR-structure"
                                         ]
                                     },
                                     {


### PR DESCRIPTION
## Summary
- Added Quick Start page with TypeScript SDK integration guide
- Reordered integration methods: SDKs (recommended, 1st) > REST APIs (2nd) > Chrome Extension (3rd)
- Moved EkaScribe SDKs above APIs in sidebar, TypeScript SDK first
- Fixed SDK sidebar titles with proper casing (iOS SDK, TypeScript SDK, etc.)
- Nested deprecated APIs under EkaScribe APIs with warning icons and deprecation banners
- Renamed "IP Allowlisting" folder to "System Requirements", added "System Requirements for Extension"
- Removed unused ip-whitelisting-for-clients nav entry