### PR TITLE
Simplify Quick Start: remove getConfig step, add TS SDK doc reference

### DIFF
--- a/api-reference/health-ai/ekascribe/quick-start.mdx
+++ b/api-reference/health-ai/ekascribe/quick-start.mdx
@@ -55,10 +55,7 @@ const sdkConfig = {
 // Get instance and use it throughout your application
 const ekascribe = getEkaScribeInstance(sdkConfig);
 
-// 2. Fetch available configurations (languages, templates, etc.)
-const config = await ekascribe.getEkascribeConfig();
-
-// 3. Initialize a transcription session
+// 2. Initialize a transcription session
 await ekascribe.initTransaction({
   mode: 'consultation',
   input_language: ['en-IN'],
@@ -68,15 +65,15 @@ await ekascribe.initTransaction({
   model_type: 'pro',
 });
 
-// 4. Start recording - microphone permission will be requested
+// 3. Start recording - microphone permission will be requested
 await ekascribe.startRecording();
 
 // ... consultation happens ...
 
-// 5. Stop recording - SDK handles chunking, upload & commit automatically
+// 4. Stop recording - SDK handles chunking, upload & commit automatically
 await ekascribe.endRecording();
 
-// 6. Get the structured output
+// 5. Get the structured output
 const result = await ekascribe.pollSessionOutput({
   txn_id: 'unique-transaction-id',
 });
@@ -84,7 +81,7 @@ const result = await ekascribe.pollSessionOutput({
 console.log(result);
 ```
 
-That's it. The SDK handles VAD, audio chunking, file uploads, retries, and polling - you just call the methods.
+That's it. The SDK handles VAD, audio chunking, file uploads, retries, and polling - you just call the methods. For error handling, token management, and other details, refer to the complete [TypeScript SDK documentation](/api-reference/health-ai/ekascribe/SDKs/TS-sdk).
 
 ---
 


### PR DESCRIPTION
## Summary
- Removed `getEkascribeConfig()` step from Quick Start code example
- Renumbered remaining steps (2-5)
- Added reference to complete TypeScript SDK documentation for error handling and other details