### PR TITLE
Fix TS SDK GitHub link and add npm references

### DIFF
--- a/api-reference/health-ai/ekascribe/SDKs/TS-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/TS-sdk.mdx
@@ -22,6 +22,8 @@ Before getting started, ensure you have:
 
 ## Installation
 
+[GitHub Repository](https://github.com/eka-care/eka-js-sdk) | [npm Package](https://www.npmjs.com/package/@eka-care/ekascribe-ts-sdk)
+
 Install the SDK using `npm` or `yarn`:
 
 ```bash
@@ -1422,4 +1424,4 @@ ekascribe.onPartialResultCallback((partialData) => {
 | `no_audio_capture`    | No audio was captured during the recording session          |
 | `txn_status_mismatch` | Invalid operation due to mismatched transaction status      |
 
-Refer [Ekascribe](https://github.com/eka-care/v2rx-extension) for SDK implementations.
+Refer [Ekascribe](https://github.com/eka-care/eka-js-sdk) for SDK implementations.

--- a/api-reference/health-ai/ekascribe/quick-start.mdx
+++ b/api-reference/health-ai/ekascribe/quick-start.mdx
@@ -86,6 +86,8 @@ console.log(result);
 
 That's it. The SDK handles VAD, audio chunking, file uploads, retries, and polling - you just call the methods.
 
+**TypeScript SDK:** [GitHub Repository](https://github.com/eka-care/eka-js-sdk) | [npm Package](https://www.npmjs.com/package/@eka-care/ekascribe-ts-sdk)
+
 ---
 
 ## Explore Other Integration Options


### PR DESCRIPTION
## Summary
- Fixed incorrect GitHub link in TS SDK page from `eka-care/v2rx-extension` to `eka-care/eka-js-sdk`
- Added GitHub Repository and npm Package links to the TS SDK Installation section
- Added GitHub Repository and npm Package links to the Quick Start page

## Test plan
- [ ] Verify GitHub link points to correct repo: https://github.com/eka-care/eka-js-sdk
- [ ] Verify npm link points to correct package: https://www.npmjs.com/package/@eka-care/ekascribe-ts-sdk
- [ ] Check links render correctly on TS SDK and Quick Start pages