### PR TITLE
Add auto_detect language hint guidance to EkaScribe docs

### DIFF
--- a/api-reference/health-ai/ekascribe/SDKs/TS-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/TS-sdk.mdx
@@ -121,7 +121,7 @@ const result = await client.startRecording({
   uploadType: 'chunked',         // 'chunked' (default) | 'single' | 'stream'
   sessionMode: 'consultation',   // optional: 'consultation' | 'dictation'
   transcriptLanguage: 'en',      // optional: language code for transcript output
-  languageHint: ['en', 'hi'],    // optional: language codes for audio input
+  languageHint: ['en', 'hi'],    // optional: language codes for audio input. If you're not offering users a language change option in your UI, use ['auto_detect'] for the best results.
   patientDetails: {              // optional
     name: 'John Doe',
     age: '45',
@@ -802,7 +802,7 @@ ekascribe.registerCallback('onError', (event) => {
 const result = await ekascribe.startRecordingV2({
   templates: ['clinical_notes_template'], // required: template IDs (from getConfig → my_templates)
   sessionMode: 'consultation',         // optional: 'consultation' | 'dictation'
-  languageHint: ['en', 'hi'],          // optional: input audio language hints
+  languageHint: ['en', 'hi'],          // optional: input audio language hints. If you're not offering users a language change option in your UI, use ['auto_detect'] for the best results.
   transcriptLanguage: 'en',            // optional: output transcript language
   model: 'pro',                        // optional: 'pro' | 'lite'
   uploadType: 'chunked',               // optional: 'chunked' (default) | 'single'

--- a/api-reference/health-ai/ekascribe/SDKs/android-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/android-sdk.mdx
@@ -193,7 +193,7 @@ val outputFormats = listOf(
     Template(templateId = "19288d2f-81a9-46a6-b804-9651242a9b3e", templateName = "SOAP Note")
 )
 
-val languages = listOf("en-IN")
+val languages = listOf("en-IN") // If you're not offering users a language change option in your UI, use "auto_detect" for the best results.
 
 Voice2Rx.startVoice2Rx(
     mode = Voice2RxType.DICTATION.value,

--- a/api-reference/health-ai/ekascribe/SDKs/ios-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/ios-sdk.mdx
@@ -199,7 +199,7 @@ private func startRecording() async {
         // 4. Calling SDK function
         try await viewModel.startRecording(
             conversationType: VoiceConversationType.conversation,
-            inputLanguage: [InputLanguageType.english, InputLanguageType.hindi],
+            inputLanguage: [InputLanguageType.english, InputLanguageType.hindi], // If you're not offering users a language change option in your UI, use auto_detect for the best results.
             templates: outputFormat,
             modelType: ModelType.lite
         )

--- a/api-reference/health-ai/ekascribe/SDKs/java-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/java-sdk.mdx
@@ -83,6 +83,8 @@ Eka Care supports transcription in multiple languages. Specify the appropriate l
 | `mr` | Marathi |
 | `pa` | Punjabi |
 
+If you're not offering users a language change option in your UI, use `auto_detect` for the best results.
+
 
 ## Step 1: Register Webhook (One-time Setup)
 
@@ -154,7 +156,7 @@ extraData.put("hfid", "unique_health_facility_id");
 
 // Define the output format for the V2RX action
 Map<String, Object> outputFormat = new HashMap<>();
-outputFormat.put("input_language", Arrays.asList("en-IN", "hi"));
+outputFormat.put("input_language", Arrays.asList("en-IN", "hi")); // If you're not offering users a language change option in your UI, use "auto_detect" for the best results.
 
 // output template ids
 Map<String, Object> templateMap1 = new HashMap<>();
@@ -329,7 +331,7 @@ public class EkascribeIntegrationExample {
 
         // Define the output format for the V2RX action
         Map<String, Object> outputFormat = new HashMap<>();
-        outputFormat.put("input_language", Arrays.asList("en-IN", "hi"));
+        outputFormat.put("input_language", Arrays.asList("en-IN", "hi")); // If you're not offering users a language change option in your UI, use "auto_detect" for the best results.
 
         // output template ids
         Map<String, Object> templateMap1 = new HashMap<>();

--- a/api-reference/health-ai/ekascribe/SDKs/scribe-python-sdk.mdx
+++ b/api-reference/health-ai/ekascribe/SDKs/scribe-python-sdk.mdx
@@ -306,6 +306,8 @@ s = client.create_session(
 
 `en`, `hi`, `gu`, `kn`, `ml`, `ta`, `te`, `bn`, `mr`, `pa` (ISO 639-1 codes).
 
+If you're not offering users a language change option in your UI, use `auto_detect` for the best results.
+
 ---
 
 ## Troubleshooting

--- a/api-reference/health-ai/ekascribe/protocol/create-session.mdx
+++ b/api-reference/health-ai/ekascribe/protocol/create-session.mdx
@@ -30,7 +30,7 @@ The response's `upload_url` is tailored to the chosen `upload_type`:
 | `session_mode` | enum | No | `dictation` (default) or `consultation`. |
 | `templates` | string[] | No | Up to **2** template IDs to extract (e.g. `eka_emr_template`, `clinical_notes_template`). |
 | `model` | enum | No | `lite` (default) or `pro`. From the discovery `models` list. |
-| `language_hint` | string[] | No | ISO 639-1 code(s) hinting the spoken language(s), e.g. `["en"]`, `["hi"]`. |
+| `language_hint` | string[] | No | ISO 639-1 code(s) hinting the spoken language(s), e.g. `["en"]`, `["hi"]`. If you're not offering users a language change option in your UI, use `["auto_detect"]` for the best results. |
 | `transcript_language` | string | No | ISO 639-1 code for the transcript output language. |
 | `upload_type` | enum | **Yes** | `chunked`, `single`, or `stream`. |
 | `communication_protocol` | enum | **Yes** | `http`, `websocket`, or `rpc`. |

--- a/api-reference/health-ai/ekascribe/quick-start.mdx
+++ b/api-reference/health-ai/ekascribe/quick-start.mdx
@@ -61,7 +61,7 @@ const config = await ekascribe.getEkascribeConfig();
 // 3. Initialize a transcription session
 await ekascribe.initTransaction({
   mode: 'consultation',
-  input_language: ['en-IN'],
+  input_language: ['en-IN'], // If you're not offering users a language change option in your UI, use ['auto_detect'] for the best results.
   output_format_template: [{ template_id: 'your_template_id' }],
   txn_id: 'unique-transaction-id',
   transfer: 'vaded',


### PR DESCRIPTION
## What

Adds a short note across the EkaScribe documentation telling integrators to use `auto_detect` for the input language hint when they don't expose a language picker in their UI.

## Where

- **Quick Start** — `quick-start.mdx`
- **SDKs** — TypeScript, Java, Android, iOS, Python
- **Protocol** — Create Session `language_hint` parameter row

The note reads: *"If you're not offering users a language change option in your UI, use `auto_detect` for the best results."*

## Notes

- Discovery page and the `auto_detection` API field were left untouched.